### PR TITLE
NETCDF multi-arrays and integration with xarray

### DIFF
--- a/Strain_Tools/strain/compare_strain_grids.py
+++ b/Strain_Tools/strain/compare_strain_grids.py
@@ -52,6 +52,7 @@ def visualize_grid_means(MyParams, ds):
                              MyParams.outdir + "/means_azimuth.png");
     pygmt_plots.plot_rotation(ds['rotation'], [], MyParams.range_strain, MyParams.outdir,
                               MyParams.outdir + "/means_rot.png");
+    plt.close('all') # clear the memory cache
 
 
 # --------- COMPUTE FUNCTION ----------- #

--- a/Strain_Tools/strain/compare_strain_grids.py
+++ b/Strain_Tools/strain/compare_strain_grids.py
@@ -1,3 +1,4 @@
+import matplotlib.pyplot as plt
 import numpy as np
 import os
 import xarray as xr

--- a/Strain_Tools/strain/output_manager.py
+++ b/Strain_Tools/strain/output_manager.py
@@ -22,12 +22,12 @@ def outputs_2d(xdata, ydata, rot, exx, exy, eyy, MyParams, myVelfield):
             "azimuth":  (("y", "x"), azimuth),
             "rotation":  (("y", "x"), rot),
             "I2":  (("y", "x"), I2nd),
-            "dilatation":  (("y", "x"), max_shear),
-            "max_shear":  (("y", "x"), dilatation),
+            "dilatation":  (("y", "x"), dilatation),
+            "max_shear":  (("y", "x"), max_shear),
         },
         coords={
-            "x": xdata,
-            "y": ydata,
+            "x": ('x', xdata),
+            "y": ('y', ydata),
         },
     )
     ds.to_netcdf(os.path.join(MyParams.outdir, '{}_strain.nc'.format(MyParams.strain_method)))
@@ -51,7 +51,6 @@ def outputs_2d(xdata, ydata, rot, exx, exy, eyy, MyParams, myVelfield):
                               negative_eigs, MyParams.outdir+'max_shear.png');
     pygmt_plots.plot_azimuth(ds['azimuth'], MyParams.range_strain, MyParams.outdir, positive_eigs,
                              negative_eigs, MyParams.outdir+'azimuth.png');
-    return;
 
 
 def outputs_1d(xcentroid, ycentroid, polygon_vertices, rot, exx, exy, eyy, range_strain, myVelfield, outdir):
@@ -82,7 +81,6 @@ def outputs_1d(xcentroid, ycentroid, polygon_vertices, rot, exx, exy, eyy, range
                                    negative_eigs, outdir+'polygon_dilatation.eps');
     pygmt_plots.plot_I2nd_1D(range_strain, polygon_vertices, I2nd, outdir, positive_eigs,
                              negative_eigs, outdir+'polygon_I2nd.eps');
-    return;
 
 
 def get_grid_eigenvectors(xdata, ydata, w1, w2, v00, v01, v10, v11):

--- a/Strain_Tools/strain/output_manager.py
+++ b/Strain_Tools/strain/output_manager.py
@@ -1,8 +1,9 @@
 # The output manager for Strain analysis.
 # ----------------- OUTPUTS -------------------------
-
 import numpy as np
-from Tectonic_Utils.read_write import netcdf_read_write
+import os
+from xarray import Dataset
+
 from . import strain_tensor_toolbox, velocity_io, pygmt_plots
 
 
@@ -11,14 +12,26 @@ def outputs_2d(xdata, ydata, rot, exx, exy, eyy, MyParams, myVelfield):
     velocity_io.write_stationvels(myVelfield, MyParams.outdir+"tempgps.txt");
     [I2nd, max_shear, dilatation, azimuth] = strain_tensor_toolbox.compute_derived_quantities(exx, exy, eyy);
     [e1, e2, v00, v01, v10, v11] = strain_tensor_toolbox.compute_eigenvectors(exx, exy, eyy);
-    netcdf_read_write.write_netcdf4(xdata, ydata, exx, MyParams.outdir + 'exx.nc');
-    netcdf_read_write.write_netcdf4(xdata, ydata, exy, MyParams.outdir + 'exy.nc');
-    netcdf_read_write.write_netcdf4(xdata, ydata, eyy, MyParams.outdir + 'eyy.nc');
-    netcdf_read_write.write_netcdf4(xdata, ydata, azimuth, MyParams.outdir + 'azimuth.nc');
-    netcdf_read_write.write_netcdf4(xdata, ydata, I2nd, MyParams.outdir + 'I2nd.nc');
-    netcdf_read_write.write_netcdf4(xdata, ydata, rot, MyParams.outdir + 'rot.nc');
-    netcdf_read_write.write_netcdf4(xdata, ydata, dilatation, MyParams.outdir + 'dila.nc');
-    netcdf_read_write.write_netcdf4(xdata, ydata, max_shear, MyParams.outdir + 'max_shear.nc');
+
+    # First create an xarray data multi-cube to write
+    ds = Dataset(
+        {
+            "exx": (("y", "x"), exx),
+            "eyy": (("y", "x"), eyy),
+            "exy": (("y", "x"), exy),
+            "azimuth":  (("y", "x"), azimuth),
+            "rotation":  (("y", "x"), rot),
+            "I2":  (("y", "x"), I2nd),
+            "dilatation":  (("y", "x"), max_shear),
+            "max_shear":  (("y", "x"), dilatation),
+        },
+        coords={
+            "x": xdata,
+            "y": ydata,
+        },
+    )
+    ds.to_netcdf(os.path.join(MyParams.outdir, '{}_strain.nc'.format(MyParams.strain_method)))
+
     print("Max I2: %f " % (np.amax(I2nd)));
     print("Min/Max rot:   %f,   %f " % (np.nanmin(rot), np.nanmax(rot)) );
 
@@ -28,15 +41,15 @@ def outputs_2d(xdata, ydata, rot, exx, exy, eyy, MyParams, myVelfield):
     velocity_io.write_gmt_format(negative_eigs, MyParams.outdir + 'negative_eigs.txt');
 
     # PYGMT PLOTS
-    pygmt_plots.plot_rotation(MyParams.outdir+'rot.nc', myVelfield, MyParams.range_strain, MyParams.outdir,
+    pygmt_plots.plot_rotation(ds['rotation'], myVelfield, MyParams.range_strain, MyParams.outdir,
                               MyParams.outdir+'rotation.png');
-    pygmt_plots.plot_dilatation(MyParams.outdir+'dila.nc', MyParams.range_strain, MyParams.outdir, positive_eigs,
+    pygmt_plots.plot_dilatation(ds['dilatation'], MyParams.range_strain, MyParams.outdir, positive_eigs,
                                 negative_eigs, MyParams.outdir+'dilatation.png');
-    pygmt_plots.plot_I2nd(MyParams.outdir+'I2nd.nc', MyParams.range_strain, MyParams.outdir, positive_eigs,
+    pygmt_plots.plot_I2nd(ds['I2'], MyParams.range_strain, MyParams.outdir, positive_eigs,
                           negative_eigs, MyParams.outdir+'I2nd.png');
-    pygmt_plots.plot_maxshear(MyParams.outdir+'max_shear.nc', MyParams.range_strain, MyParams.outdir, positive_eigs,
+    pygmt_plots.plot_maxshear(ds['max_shear'], MyParams.range_strain, MyParams.outdir, positive_eigs,
                               negative_eigs, MyParams.outdir+'max_shear.png');
-    pygmt_plots.plot_azimuth(MyParams.outdir+'azimuth.nc', MyParams.range_strain, MyParams.outdir, positive_eigs,
+    pygmt_plots.plot_azimuth(ds['azimuth'], MyParams.range_strain, MyParams.outdir, positive_eigs,
                              negative_eigs, MyParams.outdir+'azimuth.png');
     return;
 

--- a/Strain_Tools/strain/pygmt_plots.py
+++ b/Strain_Tools/strain/pygmt_plots.py
@@ -207,14 +207,10 @@ def plot_method_differences(strain_dictionary, average_strains, region, outdir, 
                     fig.coast(region=region, projection=proj, N='1', W='1.0p,black', S='lightblue');
                     for counter, name in enumerate(strain_dictionary.keys()):
                         if counter == index:
-                            plotting_data = np.subtract(strain_dictionary[name][2], average_strains);
-                            netcdf_read_write.produce_output_netcdf(strain_dictionary[name][0],
-                                                                    strain_dictionary[name][1], plotting_data,
-                                                                    'per year', outdir + "/temp.grd");
-                            fig.grdimage(outdir+'/temp.grd', projection=proj, region=region, C=outdir+"/mycpt.cpt");
+                            plotting_data = strain_dictionary[name] - average_strains
+                            fig.grdimage(plotting_data, projection=proj, region=region, C=outdir+"/mycpt.cpt");
                             fig.coast(region=region, projection=proj, N='1', W='1.0p,black', S='lightblue');
                             fig.text(position="BL", text=name+" minus mean", region=region, D='0/0.1i');
     fig.colorbar(D="JCR+w4.0i+v+o0.7i/-0.5i", C=outdir+"/mycpt.cpt", G="-300/300", B=["x50", "y+L\"Nanostr/yr\""]);
     print("Saving Method Differences as %s." % outfile);
     fig.savefig(outfile);
-    return;

--- a/Strain_Tools/strain/pygmt_plots.py
+++ b/Strain_Tools/strain/pygmt_plots.py
@@ -1,6 +1,5 @@
 import pygmt
 import numpy as np
-from Tectonic_Utils.read_write import netcdf_read_write
 
 
 def station_vels_to_arrays(station_vels):

--- a/Strain_Tools/strain/pygmt_plots.py
+++ b/Strain_Tools/strain/pygmt_plots.py
@@ -77,7 +77,7 @@ def plot_I2nd(filename, region, outdir, positive_eigs, negative_eigs, outfile):
     fig.plot(x=region[0] + 1.1, y=region[2] + 0.1, style='v0.20+b+a40+gred+h0.5+p0.3p,black+z0.003+n0.3',
              pen='0.6p,black', direction=[[-200], [0]]);
     fig.text(x=region[0] + 0.4, y=region[2] + 0.1, text="200 ns/yr", font='10p,Helvetica,black');
-    fig.colorbar(D="JCR+w4.0i+v+o0.7i/0i", C=outdir+"/mycpt.cpt", G="-1/5", B=["x1", "y+L\"Log(I2)\""]);
+    fig.colorbar(D="JCR+w4.0i+v+o0.7i/0i", C=outdir+"/mycpt.cpt", G="-1/5", B=["x1", "y+L\"Log10(|I2|)\""]);
     print("Saving I2nd figure as %s." % outfile)
     fig.savefig(outfile);
     return;

--- a/Strain_Tools/strain/strain_tensor_toolbox.py
+++ b/Strain_Tools/strain/strain_tensor_toolbox.py
@@ -199,9 +199,10 @@ def compute_derived_quantities(exx, exy, eyy):
     :rtype: list
     """
 
-    I2nd = np.zeros(np.shape(exx));
-    max_shear = np.zeros(np.shape(exx));
-    dilatation = np.zeros(np.shape(exx));
+    I2nd = exx*eyy - np.square(exy)
+    max_shear = np.sqrt(np.square(exx - eyy) + np.square(exy))
+    dilatation = 0.5*(exx + eyy)
+
     azimuth = np.zeros(np.shape(exx));
     [e1, e2, v00, v01, v10, v11] = compute_eigenvectors(exx, exy, eyy);
 
@@ -210,17 +211,11 @@ def compute_derived_quantities(exx, exy, eyy):
         datalength = dshape[0];
         print("Computing strain invariants for 1d dataset with length %d." % datalength);
         for i in range(datalength):
-            dilatation[i] = e1[i] + e2[i];
-            I2nd[i] = np.log10(np.abs(second_invariant(e1[i], 0, e2[i])));
-            max_shear[i] = abs((-e1[i] + e2[i]) / 2);
             azimuth[i] = compute_max_shortening_azimuth(e1[i], e2[i], v00[i], v01[i], v10[i], v11[i]);
     elif len(dshape) == 2:
         print("Computing strain invariants for 2d dataset.");
         for j in range(dshape[0]):
             for i in range(dshape[1]):
-                I2nd[j][i] = np.log10(np.abs(second_invariant(e1[j][i], 0, e2[j][i])));
-                max_shear[j][i] = abs((e1[j][i] - e2[j][i]) / 2);
-                dilatation[j][i] = e1[j][i] + e2[j][i];
                 azimuth[j][i] = compute_max_shortening_azimuth(e1[j][i], e2[j][i], v00[j][i], v01[j][i],
                                                                v10[j][i], v11[j][i]);
     return [I2nd, max_shear, dilatation, azimuth];

--- a/Strain_Tools/strain/strain_tensor_toolbox.py
+++ b/Strain_Tools/strain/strain_tensor_toolbox.py
@@ -21,74 +21,6 @@ def strain_on_regular_grid(dx, dy, V1, V2):
     return e11, e22, e12, rot
 
 
-def second_invariant(exx, exy, eyy):
-    """
-    :param exx: strain component
-    :type exx: float
-    :param exy: strain component
-    :type exy: float
-    :param eyy: strain component
-    :type eyy: float
-    :returns: second invariant, in units of (strain_component)^2
-    :rtype: float
-    """
-    e2nd = exx * eyy - exy * exy;
-    return e2nd;
-
-
-def eigenvector_eigenvalue(exx, exy, eyy):
-    """
-    :param exx: strain component
-    :type exx: float
-    :param exy: strain component
-    :type exy: float
-    :param eyy: strain component
-    :type eyy: float
-    :returns: [eigenvalue1 eigenvalue2 eigenvectors]
-    :rtype: list
-    """
-    if np.isnan(np.sum([exx, exy, eyy])):
-        v = [[np.nan, np.nan], [np.nan, np.nan]];
-        return [0, 0, v];
-    T = np.array([[exx, exy], [exy, eyy]]);  # the tensor
-    w, v = np.linalg.eig(T);  # The eigenvectors and eigenvalues (principal strains) of the strain rate tensor
-    return [w[0], w[1], v];
-
-
-def max_shear_strain(exx, exy, eyy):
-    """
-    :param exx: strain component
-    :type exx: float
-    :param exy: strain component
-    :type exy: float
-    :param eyy: strain component
-    :type eyy: float
-    :returns: max shear, in units of strain_component
-    :rtype: float
-    """
-    if np.isnan(np.sum([exx, exy, eyy])):
-        return 0;
-    T = np.array([[exx, exy], [exy, eyy]]);  # the tensor
-    w, v = np.linalg.eig(T);  # The eigenvectors and eigenvalues (principal strains) of the strain rate tensor
-    # w = eigenvalues; v = eigenvectors
-    max_shear = (w[0] - w[1]) * 0.5;
-    return max_shear;
-
-
-def compute_displacement_gradients(up, vp, ur, vr, uq, vq, dx, dy):
-    """
-    up, vp : velocity at a reference point P
-    uq, vq, dx : velocity at point Q, which is offset from reference point P by dx in the x direction
-    ur, vr, dy : velocity at point R, which is offset from reference point P by dy in the y direction
-    In practical usage, these are in mm/yr and km.
-    """
-    dudx = (uq - up) / dx;
-    dvdx = (vq - vp) / dx;
-    dudy = (ur - up) / dy;
-    dvdy = (vr - vp) / dy;
-    return [dudx, dvdx, dudy, dvdy];
-
-
 def compute_strain_components_from_dx(dudx, dvdx, dudy, dvdy):
     """
     Given a displacement tensor, compute the relevant parts of the strain and rotation tensors.
@@ -116,37 +48,39 @@ def compute_strain_components_from_dx(dudx, dvdx, dudy, dvdy):
     return [exx, exy, eyy, rot];
 
 
-def compute_max_shortening_azimuth(e1, e2, v00, v01, v10, v11):
+def compute_derived_quantities(exx, exy, eyy):
     """
-    :param e1: eigenvalue 1
-    :type e1: float
-    :param e2: eigenvalue 2
-    :type e2: float
-    :param v00: eigenvector 1
-    :type v00: float
-    :param v01: eigenvector 1
-    :type v01: float
-    :param v10: eigenvector 2
-    :type v10: float
-    :param v11: eigenvector 2
-    :type v11: float
-    :returns: azimuth of maximum shortening axis, in degrees CW from north
-    :rtype: float
+    Given the basic components of the strain tensor, compute the rest of the derived quantities
+    like 2nd invariant, azimuth of maximum strain, dilatation, etc.
+    exx, eyy can be 1d arrays or 2D arrays
+
+    :param exx: strain component, float or 1d array
+    :param exy: strain component, float or 1d array
+    :param eyy: strain component, float or 1d array
+    :rtype: list
     """
-    if e1 < e2:
-        maxv = np.array([v00, v10])
-    else:
-        maxv = np.array([v01, v11])
-    strike = np.arctan2(maxv[1], maxv[0])
-    theta = 90 - m.degrees(strike)
-    if np.isnan(theta):
-        return np.nan;
-    if theta < 0:
-        theta = 180 + theta
-    elif theta > 180:
-        theta = theta - 180
-    assert (theta < 180), ValueError("Error: computing an azimuth over 180 degrees.");
-    return theta
+    # Since exx etc. are numpy arrays, we can use numpy's vectorized math
+    I2nd = np.log10(np.abs(exx*eyy - np.square(exy)))
+    max_shear = np.sqrt(np.square(exx - eyy) + np.square(exy))
+    dilatation = 0.5*(exx + eyy)
+
+    # Azimuth is tricky so leaving it as a for-loop for now
+    azimuth = np.zeros(np.shape(exx));
+    [e1, e2, v00, v01, v10, v11] = compute_eigenvectors(exx, exy, eyy);
+
+    dshape = np.shape(exx);
+    if len(dshape) == 1:
+        datalength = dshape[0];
+        print("Computing strain invariants for 1d dataset with length %d." % datalength);
+        for i in range(datalength):
+            azimuth[i] = compute_max_shortening_azimuth(e1[i], e2[i], v00[i], v01[i], v10[i], v11[i]);
+    elif len(dshape) == 2:
+        print("Computing strain invariants for 2d dataset.");
+        for j in range(dshape[0]):
+            for i in range(dshape[1]):
+                azimuth[j][i] = compute_max_shortening_azimuth(e1[j][i], e2[j][i], v00[j][i], v01[j][i],
+                                                               v10[j][i], v11[j][i]);
+    return [I2nd, max_shear, dilatation, azimuth];
 
 
 def compute_eigenvectors(exx, exy, eyy):
@@ -187,40 +121,56 @@ def compute_eigenvectors(exx, exy, eyy):
     return [e1, e2, v00, v01, v10, v11];
 
 
-def compute_derived_quantities(exx, exy, eyy):
+def eigenvector_eigenvalue(exx, exy, eyy):
     """
-    Given the basic components of the strain tensor, compute the rest of the derived quantities
-    like 2nd invariant, azimuth of maximum strain, dilatation, etc.
-    exx, eyy can be 1d arrays or 2D arrays
-
-    :param exx: strain component, float or 1d array
-    :param exy: strain component, float or 1d array
-    :param eyy: strain component, float or 1d array
+    :param exx: strain component
+    :type exx: float
+    :param exy: strain component
+    :type exy: float
+    :param eyy: strain component
+    :type eyy: float
+    :returns: [eigenvalue1 eigenvalue2 eigenvectors]
     :rtype: list
     """
+    if np.isnan(np.sum([exx, exy, eyy])):
+        v = [[np.nan, np.nan], [np.nan, np.nan]];
+        return [0, 0, v];
+    T = np.array([[exx, exy], [exy, eyy]]);  # the tensor
+    w, v = np.linalg.eig(T);  # The eigenvectors and eigenvalues (principal strains) of the strain rate tensor
+    return [w[0], w[1], v];
 
-    # Since exx etc. are numpy arrays, we can use numpy's vectorized math
-    I2nd = np.log10(np.abs(exx*eyy - np.square(exy)))
-    max_shear = np.sqrt(np.square(exx - eyy) + np.square(exy))
-    dilatation = 0.5*(exx + eyy)
 
-    # Azimuth is tricky so leaving it as a for-loop for now
-    azimuth = np.zeros(np.shape(exx));
-    [e1, e2, v00, v01, v10, v11] = compute_eigenvectors(exx, exy, eyy);
-
-    dshape = np.shape(exx);
-    if len(dshape) == 1:
-        datalength = dshape[0];
-        print("Computing strain invariants for 1d dataset with length %d." % datalength);
-        for i in range(datalength):
-            azimuth[i] = compute_max_shortening_azimuth(e1[i], e2[i], v00[i], v01[i], v10[i], v11[i]);
-    elif len(dshape) == 2:
-        print("Computing strain invariants for 2d dataset.");
-        for j in range(dshape[0]):
-            for i in range(dshape[1]):
-                azimuth[j][i] = compute_max_shortening_azimuth(e1[j][i], e2[j][i], v00[j][i], v01[j][i],
-                                                               v10[j][i], v11[j][i]);
-    return [I2nd, max_shear, dilatation, azimuth];
+def compute_max_shortening_azimuth(e1, e2, v00, v01, v10, v11):
+    """
+    :param e1: eigenvalue 1
+    :type e1: float
+    :param e2: eigenvalue 2
+    :type e2: float
+    :param v00: eigenvector 1
+    :type v00: float
+    :param v01: eigenvector 1
+    :type v01: float
+    :param v10: eigenvector 2
+    :type v10: float
+    :param v11: eigenvector 2
+    :type v11: float
+    :returns: azimuth of maximum shortening axis, in degrees CW from north
+    :rtype: float
+    """
+    if e1 < e2:
+        maxv = np.array([v00, v10])
+    else:
+        maxv = np.array([v01, v11])
+    strike = np.arctan2(maxv[1], maxv[0])
+    theta = 90 - m.degrees(strike)
+    if np.isnan(theta):
+        return np.nan;
+    if theta < 0:
+        theta = 180 + theta
+    elif theta > 180:
+        theta = theta - 180
+    assert (theta < 180), ValueError("Error: computing an azimuth over 180 degrees.");
+    return theta
 
 
 def angle_mean_math(azimuth_values):

--- a/Strain_Tools/strain/strain_tensor_toolbox.py
+++ b/Strain_Tools/strain/strain_tensor_toolbox.py
@@ -199,10 +199,12 @@ def compute_derived_quantities(exx, exy, eyy):
     :rtype: list
     """
 
-    I2nd = exx*eyy - np.square(exy)
+    # Since exx etc. are numpy arrays, we can use numpy's vectorized math
+    I2nd = np.log10(np.abs(exx*eyy - np.square(exy)))
     max_shear = np.sqrt(np.square(exx - eyy) + np.square(exy))
     dilatation = 0.5*(exx + eyy)
 
+    # Azimuth is tricky so leaving it as a for-loop for now
     azimuth = np.zeros(np.shape(exx));
     [e1, e2, v00, v01, v10, v11] = compute_eigenvectors(exx, exy, eyy);
 

--- a/Strain_Tools/strain/velocity_io.py
+++ b/Strain_Tools/strain/velocity_io.py
@@ -1,6 +1,7 @@
-from Tectonic_Utils.read_write import netcdf_read_write
 import collections
 import os
+import xarray as xr
+
 from . import utilities
 
 StationVel = collections.namedtuple('StationVel', ['elon', 'nlat', 'e', 'n', 'u', 'se', 'sn', 'su', 'name']);
@@ -139,7 +140,7 @@ def read_multiple_strain_files(MyParams, plot_type):
         ds = xr.load_dataset(specific_filename)
         if k == 0:
             ds_new = xr.Dataset(
-                data_vars = ds[plot_type],
+                {method: ds[plot_type]},
                 coords = ds.coords,
             )
         else:

--- a/Strain_Tools/strain/velocity_io.py
+++ b/Strain_Tools/strain/velocity_io.py
@@ -127,13 +127,17 @@ def write_multisegment_file(polygon_vertices, quantity, filename):
 # --------- READ FUNCTION ----------- #
 def read_multiple_strain_files(MyParams, plot_type):
     """
-    Read strain quantities of `filename` into a dictionary
-    Each dictionary key is a strain method
-    Each dictionary value is a data structure: [lon, lat, value]
-    lon : list of floats
-    lat : list of floats
-    value : 2D array of floats
-    We also guarantee the mutual co-registration of the dictionary elements
+    Get all the models (e.g. gpsgridder, geostats, huang, etc.) that have computed plot_type of 
+    strain rate and return them as a single xarray Dataset
+
+    Parameters
+    ----------
+    MyParams: dict - Parameter Dictionary containing strain rates in a sub-dict
+    plot_type: str - The type of strain rate quantify to return. Can be max_shear, dilatation, etc.
+    
+    Returns
+    -------
+    ds_new: xarray Dataset - A dataset containing the plot_type variable from each type of model
     """
     for k, method in enumerate(MyParams.strain_dict.keys()):
         specific_filename = os.path.join(MyParams.strain_dict[method], "{}_strain.nc".format(method))
@@ -146,6 +150,4 @@ def read_multiple_strain_files(MyParams, plot_type):
         else:
             ds_new[method] = ds[plot_type]
 
-    #utilities.check_coregistered_grids(MyParams.range_strain, MyParams.inc, strain_values_dict);
-    #utilities.check_coregistered_shapes(strain_values_dict);
     return ds_new


### PR DESCRIPTION
I wasn't sure how doing a single file with multiple variables would work with your netcdf writer, but I noticed that pygmt has native support for xarray dataarrays, so I integrated xarray into the reading/writing of the multi-array for strain rate. At some point we should also include the interpolated velocities in the file, but saving that for a later PR. I think I got everything updated but if you find a bug let me know. 

## Description
<!--- Describe your changes in detail -->
- Refactored code to use xarray Datasets for storing and writing out the strain rate variables
- Updated plotting to use the dataarrays (surprisingly little to change as pygmt natively handles xarray DataArrays)
- Also updated the max_shear, dilatation, and I2 calculation to be a bit simpler as numpy array operations are natively vectorized and I was getting some wild values 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- This allows for a single file to be written containing all the strain rate components and derived quantities on a single grid.
- This also updates the derived quantities calculation


## How Has This Been Tested?
- Ran examples with gpsgridder and huang, and then ran the comparison script