### PR TITLE
Add velocities to netcdf

### DIFF
--- a/Strain_Tools/strain/internal_coordinator.py
+++ b/Strain_Tools/strain/internal_coordinator.py
@@ -23,6 +23,6 @@ def strain_coordinator(MyParams):
     velField = input_manager.inputs(MyParams);
     strain_model = get_model(MyParams.strain_method);  # getting an object of type that inherits from Strain_2d
     constructed_object = strain_model(MyParams);   # calling the constructor, building strain model from our params
-    [lons, lats, rot, exx, exy, eyy] = constructed_object.compute(velField);  # computing strain
-    output_manager.outputs_2d(lons, lats, rot, exx, exy, eyy, MyParams, velField);  # 2D grid output format
+    [lons, lats, Ve, Vn, rot, exx, exy, eyy] = constructed_object.compute(velField);  # computing strain
+    output_manager.outputs_2d(lons, lats, Ve, Vn, rot, exx, exy, eyy, MyParams, velField);  # 2D grid output format
     return

--- a/Strain_Tools/strain/models/strain_delaunay.py
+++ b/Strain_Tools/strain/models/strain_delaunay.py
@@ -72,8 +72,11 @@ class delaunay(Strain_2d):
         # output_manager.outputs_1d(xcentroid, ycentroid, triangle_verts, rot, exx, exy, eyy, self._strain_range,
         #                           myVelfield, self._outdir);
 
+        # Velocities aren't used in Delaunay
+        Ve, Vn = np.nan*np.empty((4,4)), np.nan*np.empty((4,4))
+
         print("Success computing strain via Delaunay method.\n");
-        return [lons, lats, rot_grd, exx_grd, exy_grd, eyy_grd];
+        return [lons, lats, Ve, Vn, rot_grd, exx_grd, exy_grd, eyy_grd];
 
 
 def compute_with_delaunay_polygons(myVelfield):

--- a/Strain_Tools/strain/models/strain_delaunay.py
+++ b/Strain_Tools/strain/models/strain_delaunay.py
@@ -73,7 +73,7 @@ class delaunay(Strain_2d):
         #                           myVelfield, self._outdir);
 
         # Velocities aren't used in Delaunay
-        Ve, Vn = np.nan*np.empty((4,4)), np.nan*np.empty((4,4))
+        Ve, Vn = np.nan*np.empty(exx_grd.shape), np.nan*np.empty(exx_grd.shape)
 
         print("Success computing strain via Delaunay method.\n");
         return [lons, lats, Ve, Vn, rot_grd, exx_grd, exy_grd, eyy_grd];

--- a/Strain_Tools/strain/models/strain_delaunay_flat.py
+++ b/Strain_Tools/strain/models/strain_delaunay_flat.py
@@ -34,8 +34,17 @@ class delaunay_flat(Strain_2d):
                                                                                   triangle_verts, rot, exx, exy, eyy);
 
         # Here we output convenient things on polygons, since it's intuitive for the user.
-        output_manager.outputs_1d(xcentroid, ycentroid, triangle_verts, rot, exx, exy, eyy, self._strain_range,
-                                  myVelfield, self._outdir);
+        output_manager.outputs_1d(
+            xcentroid, 
+            ycentroid, 
+            triangle_verts, 
+            np.array(rot), 
+            np.array(exx), 
+            np.array(exy),
+            np.array(eyy),
+            self._strain_range,
+            myVelfield, self._outdir
+        );
 
         print("Success computing strain via Delaunay method.\n");
         return [lons, lats, rot_grd, exx_grd, exy_grd, eyy_grd];

--- a/Strain_Tools/strain/models/strain_delaunay_flat.py
+++ b/Strain_Tools/strain/models/strain_delaunay_flat.py
@@ -46,8 +46,11 @@ class delaunay_flat(Strain_2d):
             myVelfield, self._outdir
         );
 
+        # Velocities aren't used in Delaunay
+        Ve, Vn = np.nan*np.empty((4,4)), np.nan*np.empty((4,4))
+
         print("Success computing strain via Delaunay method.\n");
-        return [lons, lats, rot_grd, exx_grd, exy_grd, eyy_grd];
+        return [lons, lats, Ve, Vn, rot_grd, exx_grd, exy_grd, eyy_grd];
 
 
 # ----------------- COMPUTE -------------------------

--- a/Strain_Tools/strain/models/strain_geostats.py
+++ b/Strain_Tools/strain/models/strain_geostats.py
@@ -161,9 +161,8 @@ class geostats(Strain_2d):
         Vn = Dest_n.reshape(self._grid_shape)
 
         # Compute strain rates
-        exx, eyy, exy, rot = strain_on_regular_grid(
-                self._grid_inc[0]*111, self._grid_inc[1]*111, Ve, Vn
-            )
+        dx, dy =  self._grid_inc[0] * 111 * np.cos(np.deg2rad(self._strain_range[2])), self._grid_inc[1] * 111
+        exx, eyy, exy, rot = strain_on_regular_grid(dx, dy, Ve, Vn)
 
         # Return the strain rates etc.
         return self._lons, self._lats, Ve, Vn, rot, exx, exy, eyy

--- a/Strain_Tools/strain/models/strain_geostats.py
+++ b/Strain_Tools/strain/models/strain_geostats.py
@@ -157,16 +157,16 @@ class geostats(Strain_2d):
         self.setPoints(xy=xy, data = n)
         Dest_n, Dsig_n, _ = self.krige()
         
+        Ve = Dest_e.reshape(self._grid_shape)
+        Vn = Dest_n.reshape(self._grid_shape)
+
         # Compute strain rates
         exx, eyy, exy, rot = strain_on_regular_grid(
-                self._grid_inc[0]*111, 
-                self._grid_inc[1]*111, 
-                Dest_e.reshape(self._grid_shape), 
-                Dest_n.reshape(self._grid_shape)
+                self._grid_inc[0]*111, self._grid_inc[1]*111, Ve, Vn
             )
 
         # Return the strain rates etc.
-        return self._lons, self._lats, rot, exx, exy, eyy
+        return self._lons, self._lats, Ve, Vn, rot, exx, exy, eyy
         
 
 def simple_kriging(SIG, sig0, data, sig2):

--- a/Strain_Tools/strain/models/strain_gpsgridder.py
+++ b/Strain_Tools/strain/models/strain_gpsgridder.py
@@ -77,7 +77,7 @@ def compute_gpsgridder(myVelfield, range_strain, inc, poisson, fd, eigenvalue, t
     xinc = xinc * 111.000 * np.cos(np.deg2rad(range_strain[2]));  # in km (not degrees)
     yinc = yinc * 111.000;   # in km (not degrees)
 
-    [exx, eyy, exy, rot] = strain_tensor_toolbox.strain_on_regular_grid(xinc, yinc, udata/1000, vdata/1000)
+    [exx, eyy, exy, rot] = strain_tensor_toolbox.strain_on_regular_grid(xinc, yinc, udata * 1000, vdata * 1000)
 
     print("Success computing strain via gpsgridder method.\n");
     return [xdata, ydata, udata.T, vdata.T, abs(rot.T), exx.T, exy.T, eyy.T];

--- a/Strain_Tools/strain/models/strain_gpsgridder.py
+++ b/Strain_Tools/strain/models/strain_gpsgridder.py
@@ -77,16 +77,7 @@ def compute_gpsgridder(myVelfield, range_strain, inc, poisson, fd, eigenvalue, t
     xinc = xinc * 111.000 * np.cos(np.deg2rad(range_strain[2]));  # in km (not degrees)
     yinc = yinc * 111.000;   # in km (not degrees)
 
-    [exx, eyy, exy, rot] = strain_tensor_toolbox.strain_on_regular_grid(xinc, yinc, udata, vdata)
-    # Lastly we multiply by 1000 for units
-    exx = exx.T;
-    eyy = eyy.T;
-    exy = exy.T;
-    rot = rot.T;
-    exx = np.multiply(exx, 1000);
-    exy = np.multiply(exy, 1000);
-    eyy = np.multiply(eyy, 1000);
-    rot = abs(np.multiply(rot, 1000));
+    [exx, eyy, exy, rot] = strain_tensor_toolbox.strain_on_regular_grid(xinc, yinc, udata/1000, vdata/1000)
 
     print("Success computing strain via gpsgridder method.\n");
-    return [xdata, ydata, udata.T, vdata.T, rot, exx, exy, eyy];
+    return [xdata, ydata, udata.T, vdata.T, abs(rot.T), exx.T, exy.T, eyy.T];

--- a/Strain_Tools/strain/models/strain_gpsgridder.py
+++ b/Strain_Tools/strain/models/strain_gpsgridder.py
@@ -20,10 +20,10 @@ class gpsgridder(Strain_2d):
         self._poisson, self._fd, self._eigenvalue = verify_inputs_gpsgridder(params.method_specific);
 
     def compute(self, myVelfield):
-        [lons, lats, rot_grd, exx_grd, exy_grd, eyy_grd] = compute_gpsgridder(myVelfield, self._strain_range,
+        [lons, lats, Ve, Vn, rot_grd, exx_grd, exy_grd, eyy_grd] = compute_gpsgridder(myVelfield, self._strain_range,
                                                                               self._grid_inc, self._poisson, self._fd,
                                                                               self._eigenvalue, self._tempdir);
-        return [lons, lats, rot_grd, exx_grd, exy_grd, eyy_grd];
+        return [lons, lats, Ve, Vn, rot_grd, exx_grd, exy_grd, eyy_grd];
 
 
 def verify_inputs_gpsgridder(method_specific_dict):
@@ -89,4 +89,4 @@ def compute_gpsgridder(myVelfield, range_strain, inc, poisson, fd, eigenvalue, t
     rot = abs(np.multiply(rot, 1000));
 
     print("Success computing strain via gpsgridder method.\n");
-    return [xdata, ydata, rot, exx, exy, eyy];
+    return [xdata, ydata, udata.T, vdata.T, rot, exx, exy, eyy];

--- a/Strain_Tools/strain/models/strain_huang.py
+++ b/Strain_Tools/strain/models/strain_huang.py
@@ -14,10 +14,10 @@ class huang(Strain_2d):
         self._radiuskm, self._nstations = verify_inputs_huang(params.method_specific);
 
     def compute(self, myVelfield):
-        [lons, lats, rot_grd, exx_grd, exy_grd, eyy_grd] = compute_huang(myVelfield, self._strain_range,
+        [lons, lats, Ve, Vn, rot_grd, exx_grd, exy_grd, eyy_grd] = compute_huang(myVelfield, self._strain_range,
                                                                          self._grid_inc, self._radiuskm,
                                                                          self._nstations);
-        return [lons, lats, rot_grd, exx_grd, exy_grd, eyy_grd];
+        return [lons, lats, Ve, Vn, rot_grd, exx_grd, exy_grd, eyy_grd];
 
 
 def verify_inputs_huang(method_specific_dict):
@@ -141,7 +141,11 @@ def compute_huang(myVelfield, range_strain, inc, radiuskm, nstations):
 
     print("Success computing strain via Huang method.\n");
 
-    return [xlons, ylats, rot, exx, exy, eyy];
+    # I know you can get velocities out of this code but dropping this in now as a placeholder
+    Ve = np.nan*np.empty(exx.shape)
+    Vn = np.nan*np.empty(exx.shape)
+
+    return [xlons, ylats, Ve, Vn, rot, exx, exy, eyy];
 
 
 def velfield_to_huang_non_utm(myVelfield):

--- a/Strain_Tools/strain/models/strain_tape.py
+++ b/Strain_Tools/strain/models/strain_tape.py
@@ -30,7 +30,11 @@ class tape(Strain_2d):
         _, _, exy = nn_interp(x, y, exy, self._strain_range, self._grid_inc);
         _, _, eyy = nn_interp(x, y, eyy, self._strain_range, self._grid_inc);
         _, _, rot = nn_interp(x, y, rot, self._strain_range, self._grid_inc); 
-        return [lons, lats, rot, exx, exy, eyy];
+
+        # Not sure whether Tape gives velocities or not
+        Ve, Vn = np.nan*np.empty(exx.shape), np.nan*np.empty(exx.shape), 
+
+        return [lons, lats, Ve, Vn, rot, exx, exy, eyy];
 
 
 def verify_inputs_tape(method_specific_dict):

--- a/Strain_Tools/strain/models/strain_visr.py
+++ b/Strain_Tools/strain/models/strain_visr.py
@@ -22,10 +22,10 @@ class visr(Strain_2d):
         self._distwgt, self._spatwgt, self._smoothincs, self._exec = verify_inputs_visr(params.method_specific);
 
     def compute(self, myVelfield):
-        [lons, lats, rot_grd, exx_grd, exy_grd, eyy_grd] = compute_visr(myVelfield, self._strain_range, self._grid_inc,
+        [lons, lats, Ve, Vn, rot_grd, exx_grd, exy_grd, eyy_grd] = compute_visr(myVelfield, self._strain_range, self._grid_inc,
                                                                         self._distwgt, self._spatwgt,
                                                                         self._smoothincs, self._exec, self._tempdir);
-        return [lons, lats, rot_grd, exx_grd, exy_grd, eyy_grd];
+        return [lons, lats, Ve, Vn, rot_grd, exx_grd, exy_grd, eyy_grd];
 
 
 def verify_inputs_visr(method_specific_dict):
@@ -60,7 +60,11 @@ def compute_visr(myVelfield, strain_range, inc, distwgt, spatwgt, smoothincs, ex
     subprocess.call(['mv', strain_data_file, tempdir], shell=False);
     subprocess.call(['mv', strain_output_file, tempdir], shell=False);
     print("Success computing strain via Visr method.\n");
-    return [xdata, ydata, rot, exx, exy, eyy];
+
+    # I know visr allows for velocity calculation, but dropping this in here now as a placeholder
+    Ve, Vn = np.nan*np.empty((4,4)), np.nan*np.empty((4,4))
+
+    return [xdata, ydata, Ve, Vn, rot, exx, exy, eyy];
 
 
 def write_fortran_config_file(strain_config_file, strain_data_file, strain_output_file, range_strain, inc, distwgt, spatwgt, smoothincs):

--- a/Strain_Tools/strain/models/strain_visr.py
+++ b/Strain_Tools/strain/models/strain_visr.py
@@ -62,7 +62,7 @@ def compute_visr(myVelfield, strain_range, inc, distwgt, spatwgt, smoothincs, ex
     print("Success computing strain via Visr method.\n");
 
     # I know visr allows for velocity calculation, but dropping this in here now as a placeholder
-    Ve, Vn = np.nan*np.empty((4,4)), np.nan*np.empty((4,4))
+    Ve, Vn = np.nan*np.empty(exx.shape), np.nan*np.empty(exx.shape)
 
     return [xdata, ydata, Ve, Vn, rot, exx, exy, eyy];
 

--- a/Strain_Tools/strain/output_manager.py
+++ b/Strain_Tools/strain/output_manager.py
@@ -7,7 +7,7 @@ from xarray import Dataset
 from . import strain_tensor_toolbox, velocity_io, pygmt_plots
 
 
-def outputs_2d(xdata, ydata, rot, exx, exy, eyy, MyParams, myVelfield):
+def outputs_2d(xdata, ydata, Ve, Vn, rot, exx, exy, eyy, MyParams, myVelfield):
     print("------------------------------\nWriting 2d outputs:");
     velocity_io.write_stationvels(myVelfield, MyParams.outdir+"tempgps.txt");
     [I2nd, max_shear, dilatation, azimuth] = strain_tensor_toolbox.compute_derived_quantities(exx, exy, eyy);
@@ -16,6 +16,8 @@ def outputs_2d(xdata, ydata, rot, exx, exy, eyy, MyParams, myVelfield):
     # First create an xarray data multi-cube to write
     ds = Dataset(
         {
+            "Ve": (("y", "x"), Ve),
+            "Vn": (("y", "x"), Vn),
             "exx": (("y", "x"), exx),
             "eyy": (("y", "x"), eyy),
             "exy": (("y", "x"), exy),


### PR DESCRIPTION
This is a simple start to adding velocities to the output NETCDF file. This allows the interpolated velocities to be viewed in addition to the strain rates. 
- Velocities are not currently output by all of the methods, so for now I'm just having nans get put in place. This can be addressed later, as I'm pretty sure almost all of the methods have ways of getting velocity too, it's just not currently being done
- I also simplified one area by scaling velocities instead of strains