### PR TITLE
Some simplifying file I/O and data handling

### DIFF
--- a/Strain_Tools/strain/compare_strain_grids.py
+++ b/Strain_Tools/strain/compare_strain_grids.py
@@ -41,7 +41,6 @@ def compare_grid_means(MyParams, plot_type, statistics_function, mask=None):
     """
     # here we extract each grid of plot_type into an xarray.Dataset
     strain_values_ds = velocity_io.read_multiple_strain_netcdfs(MyParams, plot_type)
-    utilities.check_coregistered_shapes(strain_values_ds)
 
     # here we compute mean and standard deviation
     mean_stds_ds = compute_grid_statistics(strain_values_ds, statistics_function)

--- a/Strain_Tools/strain/compare_strain_grids.py
+++ b/Strain_Tools/strain/compare_strain_grids.py
@@ -1,3 +1,4 @@
+import glob
 import matplotlib.pyplot as plt
 import numpy as np
 import os
@@ -10,51 +11,56 @@ def drive(MyParams):
     """
     A driver for taking statistics of several strain computations
     """
-    mean_dss = xr.Dataset()
-    mean_dss['max_shear'] = compare_grid_means(MyParams, "max_shear", simple_means_statistics)
-    mean_dss['dilatation'] = compare_grid_means(MyParams, "dilatation", simple_means_statistics)
-    mean_dss['I2'] = compare_grid_means(MyParams, "I2", simple_means_statistics)
-    mean_dss['rotation'] = compare_grid_means(MyParams, "rotation", simple_means_statistics)
-    mean_dss['azimuth'] = compare_grid_means(MyParams, "azimuth", angular_means_statistics,
-                                             mask=[MyParams.outdir+'/means_I2.nc', 3])
+    mean_dss = compare_grid_means(MyParams)
     visualize_grid_means(MyParams, mean_dss)
 
 
-def compare_grid_means(MyParams, plot_type, statistics_function, mask=None):
+def compare_grid_means(MyParams, statistics_function=np.nanmean):
     """
     A driver for comparing strain rate maps
 
     Parameters
     ----------
     MyParams: dict            - Parameter dictionary
-    plot_type: str            - Type of strain quantity to compare 
-    statistics_function: func - standard numpy-compatible reducing function (e.g. mean, median, nanmedian)
-    mask:                     - length-2 list of [filename, cutoff_value] used for thresholding the plot_type
+    statistics_function: func - standard numpy-compatible reducing function (e.g. mean, 
+                                median, nanmedian)
 
     Returns
     -------
-    mean_stds_ds: xarray Dataset   - Dataset containing the mean and standard deviation of each variable
+    mean_dss: xarray Dataset   - Dataset containing the mean and standard deviation of 
+                                 each variable
 
     Writes
     ------
-    mean_ds, std_ds: xarray Dataset - writes these to NETCDF
+    mean_dss: xarray Dataset   - Dataset containing the mean and standard deviation of 
+                                 each variable
     """
-    # here we extract each grid of plot_type into an xarray.Dataset
-    strain_values_ds = velocity_io.read_multiple_strain_netcdfs(MyParams, plot_type)
+    ds_list = []
+    for key, value in MyParams.strain_dict.items():
+        specific_filename = glob.glob(value + os.sep + '*' + "_strain.nc")[0]
+        ds = xr.load_dataset(specific_filename)
+        ds_list.append(ds)
 
     # here we compute mean and standard deviation
-    mean_stds_ds = compute_grid_statistics(strain_values_ds, statistics_function)
+    mean_dss = compute_grid_statistics(ds_list, statistics_function)
+    mean_dss.to_netcdf(os.path.join(MyParams.outdir, "mean_std.nc"))
 
-    mean_stds_ds.to_netcdf(os.path.join(MyParams.outdir, "means_stds_"+str(plot_type)+".nc"))
-    if "dila" in plot_type or "max_shear" in plot_type:
-        pygmt_plots.plot_method_differences(
-            strain_values_ds,
-            mean_stds_ds['mean'],
-            MyParams.range_strain, 
-            MyParams.outdir,
-            MyParams.outdir+"/separate_plots_"+plot_type.split('.')[0]+'.png'
-        )
-    return mean_stds_ds['mean']
+    # plot differences between methods for dilatation and max shear strain rates
+    pygmt_plots.plot_method_differences(
+        velocity_io.read_multiple_strain_netcdfs(MyParams, 'dilatation'),
+        mean_dss['dilatation'],
+        MyParams.range_strain, 
+        MyParams.outdir,
+        MyParams.outdir+"/separate_plots_"+"dilatation"+'.png',
+    )
+    pygmt_plots.plot_method_differences(
+        velocity_io.read_multiple_strain_netcdfs(MyParams, 'max_shear'),
+        mean_dss['max_shear'],
+        MyParams.range_strain, 
+        MyParams.outdir,
+        MyParams.outdir+"/separate_plots_"+"max_shear"+'.png'
+    )
+    return mean_dss
 
 
 def visualize_grid_means(MyParams, ds):
@@ -73,77 +79,55 @@ def visualize_grid_means(MyParams, ds):
 
 # --------- COMPUTE FUNCTION ----------- #
 
-def compute_grid_statistics(strain_values_ds, statistic_function):
+def compute_grid_statistics(strain_grid_list, stat=np.nanmean):
     """
-    A function that takes statistics on several mutually co-registered grids in an xarray.DataSet.
-    This function basically runs a loop.
+    A function that takes statistics on several mutually co-registered 
+    grids in an xarray.DataSet. This function basically runs a loop.
     The inner function must return a mean-like value and a standard-deviation-like value
     Returns a dataset with two layers, mean and standard deviation
     """
+    exx = stat([ds['exx'].data for ds in strain_grid_list], axis=0)
+    eyy = stat([ds['eyy'].data for ds in strain_grid_list], axis=0)
+    exy = stat([ds['exy'].data for ds in strain_grid_list], axis=0)
+    rot = stat([ds['rotation'].data for ds in strain_grid_list], axis=0)
+    Ve =  stat([ds['Ve'].data for ds in strain_grid_list], axis=0)
+    Vn =  stat([ds['Vn'].data for ds in strain_grid_list], axis=0)
 
-    x = np.array(strain_values_ds['x'])
-    y = np.array(strain_values_ds['y'])
-    num_grids = len(strain_values_ds.data_vars.items())
+    exx_std = np.nanstd([ds['exx'].data for ds in strain_grid_list], axis=0)
+    eyy_std = np.nanstd([ds['eyy'].data for ds in strain_grid_list], axis=0)
+    exy_std = np.nanstd([ds['exy'].data for ds in strain_grid_list], axis=0)
 
-    # Unpacking into 3D numpy array
-    comparative_strain_values = np.zeros((len(y), len(x), num_grids))
-    for i, (varname, da) in enumerate(strain_values_ds.data_vars.items()):
-        comparative_strain_values[:, :, i] = np.array(da)
+    try:
+        Se = stat([ds['Se'].data for ds in strain_grid_list], axis=0)
+        Sn = stat([ds['Sn'].data for ds in strain_grid_list], axis=0)
+    except KeyError:
+        pass
 
-    mean_vals = np.nan * np.ones([len(y), len(x)])
-    sd_vals = np.nan * np.ones([len(y), len(x)])
-    for j in range(len(y)):
-        for i in range(len(x)):
-            mean_vals[j][i], sd_vals[j][i] = statistic_function(comparative_strain_values[j][i][:])
+    [I2nd, max_shear, dilatation, azimuth] = strain_tensor_toolbox.compute_derived_quantities(exx, exy, eyy)
 
     # Repacking result into DS
     mean_stds_ds = xr.Dataset(
         {
-            "mean": (("y", "x"), mean_vals),
-            "stds": (("y", "x"), sd_vals),
+            "exx": (("y", "x"), exx),
+            "eyy": (("y", "x"), eyy),
+            "exy": (("y", "x"), exy),
+            "rotation": (("y", "x"), rot),
+            "max_shear": (("y", "x"), max_shear),
+            "dilatation": (("y", "x"), dilatation),
+            "I2": (("y", "x"), I2nd),
+            "azimuth": (("y", "x"), azimuth),
+            "exx_std": (("y", "x"), exx_std),
+            "eyy_std": (("y", "x"), eyy_std),
+            "exy_std": (("y", "x"), exy_std),
         },
         coords={
-            "x": ('x', x),
-            "y": ('y', y),
+            "x": ('x', strain_grid_list[0].x.data),
+            "y": ('y', strain_grid_list[0].y.data),
         },
     )
+
+    
+    
     return mean_stds_ds
 
 
-def simple_means_statistics(value_list):
-    """
-    Take simple mean and standard deviation of a list of values
-    """
-    mean_val = np.nanmean(value_list)
-    sd_val = np.nanstd(value_list)
-    if mean_val == float("-inf"):
-        mean_val = np.nan
-    return mean_val, sd_val
-
-
-def log_means_statistics(value_list):
-    """
-    Take mean and standard deviation of a list of values that are log quantities
-    """
-    value_list = [10 ** x for x in value_list]
-    mean_val = np.nanmean(value_list)
-    sd_val = np.nanstd(value_list)
-    if mean_val != float("-inf"):
-        mean_val = np.log10(mean_val)
-    else:
-        mean_val = np.nan
-    sd_val = np.log10(sd_val)
-    return mean_val, sd_val
-
-
-def angular_means_statistics(value_list):
-    """
-    Take mean and standard deviation of a list of values that are azimuths
-    """
-    mean_val, sd_val = np.nan, np.nan
-    theta, sd = strain_tensor_toolbox.angle_mean_math(value_list)
-    if theta != float("-inf"):
-        mean_val = theta
-    if sd != float("inf"):
-        sd_val = sd
-    return mean_val, sd_val

--- a/Strain_Tools/strain/models/strain_visr.py
+++ b/Strain_Tools/strain/models/strain_visr.py
@@ -27,11 +27,13 @@ class visr(Strain_2d):
         self._num_creep_faults, self._creep_file, self._exec = verify_inputs_visr(params.method_specific)
 
     def compute(self, myVelfield):
-        [Ve, Vn, rot_grd, exx_grd, exy_grd, eyy_grd] = compute_visr(myVelfield, self._strain_range, self._grid_inc,
-                                                                    self._xdata, self._ydata,
-                                                                    self._distwgt, self._spatwgt, self._smoothincs,
-                                                                    self._wgt, self._unc_thresh, self._num_creep_faults,
-                                                                    self._creep_file, self._exec, self._tempdir)
+        [Ve, Vn, rot_grd, exx_grd, exy_grd, eyy_grd] = compute_visr(
+            myVelfield, self._strain_range, self._grid_inc,
+            self._xdata, self._ydata,
+            self._distwgt, self._spatwgt, self._smoothincs,
+            self._wgt, self._unc_thresh, self._num_creep_faults,
+            self._creep_file, self._exec, self._tempdir
+        )
         # Report observed and residual velocities within bounding box
         velfield_within_box = utilities.filter_by_bounding_box(myVelfield, self._strain_range)
         model_velfield = utilities.create_model_velfield(self._xdata, self._ydata, Ve, Vn, velfield_within_box)
@@ -67,8 +69,10 @@ def verify_inputs_visr(method_specific_dict):
            num_creep_faults, creep_file, executable
 
 
-def compute_visr(myVelfield, strain_range, inc, xdata, ydata, distwgt, spatwgt, smoothincs, wgt, unc_thresh,
-                 num_creep_faults, creep_file, executable, tempdir):
+def compute_visr(
+        myVelfield, strain_range, inc, xdata, ydata, distwgt, spatwgt, smoothincs, wgt, unc_thresh,
+        num_creep_faults, creep_file, executable, tempdir
+    ):
     print("------------------------------\nComputing strain via Visr method.")
     strain_config_file = 'visr_strain.drv'
     strain_data_file = 'strain_input.txt'  # can only be 20 characters long bc fortran!
@@ -77,13 +81,19 @@ def compute_visr(myVelfield, strain_range, inc, xdata, ydata, distwgt, spatwgt, 
                               spatwgt, smoothincs, wgt, unc_thresh, num_creep_faults, creep_file)
     write_fortran_data_file(strain_data_file, myVelfield)
     check_fortran_executable(executable)
+
     call_fortran_compute(strain_config_file, executable)
 
     # We convert that text file into grids, which we will write as GMT grd files.
-    [Ve, Vn, rot, exx, exy, eyy] = make_output_grids_from_strain_out(strain_output_file, xdata, ydata)
+    try:
+        [Ve, Vn, rot, exx, exy, eyy] = make_output_grids_from_strain_out(strain_output_file, xdata, ydata)
+    except FileNotFoundError:
+        raise RuntimeError('VISR failed for some reason')
+
     shutil.move(src=strain_config_file, dst=os.path.join(tempdir, strain_config_file))
     shutil.move(src=strain_data_file, dst=os.path.join(tempdir, strain_data_file))
     shutil.move(src=strain_output_file, dst=os.path.join(tempdir, strain_output_file))
+
     print("Success computing strain via Visr method.\n")
 
     return [Ve, Vn, rot, exx, exy, eyy]

--- a/Strain_Tools/strain/models/strain_wavelets.py
+++ b/Strain_Tools/strain/models/strain_wavelets.py
@@ -17,7 +17,7 @@ class wavelets(Strain_2d):
         # Setup for Matlab calculation
         configure_file = self._outdir + "surfacevel2strain_config_params.txt"
         velocity_file = self._outdir + "vel_wavelets.txt"
-        os.makedirs(self._code_dir+'/matlab_output', exist_ok=True)
+        os.makedirs(self._code_dir+ os.sep + 'matlab_output', exist_ok=True)
         write_to_wavelets_vel_format(myVelfield, velocity_file)
         write_wavelets_parameter_file(self._data_range, self._code_dir, self._qmin, self._qmax, self._qsec,
                                       velocity_file, configure_file)

--- a/Strain_Tools/strain/pygmt_plots.py
+++ b/Strain_Tools/strain/pygmt_plots.py
@@ -49,6 +49,7 @@ def filter_vectors_to_land_only(region, elon, nlat, e, n):
 
 
 def plot_rotation(rotation_array, station_vels, region, outdir, outfile,peak_max_shear = 300):
+    scalesize = get_map_scale(region)
     proj = 'M4i'
     fig = pygmt.Figure()
     scalesize = get_map_scale(region)

--- a/Strain_Tools/strain/pygmt_plots.py
+++ b/Strain_Tools/strain/pygmt_plots.py
@@ -48,13 +48,13 @@ def filter_vectors_to_land_only(region, elon, nlat, e, n):
     return newelon, newnlat, newe, newn
 
 
-def plot_rotation(rotation_array, station_vels, region, outdir, outfile):
+def plot_rotation(rotation_array, station_vels, region, outdir, outfile,peak_max_shear = 300):
     proj = 'M4i'
     fig = pygmt.Figure()
     scalesize = get_map_scale(region)
-    pygmt.makecpt(cmap="magma", series="0/300/1", truncate="0.3/1.0", background="o",
-                  output=os.path.join(outdir, "mycpt.cpt"))
-    fig.basemap(region=region, projection=proj, frame="+tRotation")
+    pygmt.makecpt(cmap="magma", series=f"0/{peak_max_shear}/1", truncate="0.3/1.0", 
+                  background="o", output=os.path.join(outdir, "mycpt.cpt"))
+    fig.basemap(region=region, projection=proj, frame="+t\"Rotation\"")
     fig.grdimage(rotation_array, region=region, cmap=os.path.join(outdir, "mycpt.cpt"))
     fig.coast(region=region, projection=proj, borders='1', shorelines='1.0p,black', water='lightblue',
               map_scale="n0.12/0.12+c" + str(region[2]) + "+w"+str(scalesize), frame="1.0")
@@ -73,11 +73,11 @@ def plot_rotation(rotation_array, station_vels, region, outdir, outfile):
     return
 
 
-def plot_dilatation(dila_array, station_vels, region, outdir, outfile, positive_eigs=(), negative_eigs=()):
+def plot_dilatation(dila_array, station_vels, region, outdir, outfile, positive_eigs=(), negative_eigs=(), peak_dil=75):
     proj = 'M4i'
     fig = pygmt.Figure()
     scalesize = get_map_scale(region)
-    pygmt.makecpt(cmap="vik", series="-200/200/2", background="o",
+    pygmt.makecpt(cmap="vik", series=f"-{peak_dil}/{peak_dil}/2", background="o", 
                   output=os.path.join(outdir, "mycpt.cpt"))
     fig.basemap(region=region, projection=proj, frame="+tDilatation")
     fig.grdimage(dila_array, region=region, cmap=os.path.join(outdir, "mycpt.cpt"))
@@ -103,9 +103,9 @@ def plot_dilatation(dila_array, station_vels, region, outdir, outfile, positive_
              pen='0.6p,black', direction=[[200], [0]], offset="0.9i/0.1i")
     fig.plot(x=region[0], y=region[2], style='v0.20+b+a40+gred+h0.5+p0.3p,black+z0.003+n0.3',
              pen='0.6p,black', direction=[[-200], [0]], offset="0.9i/0.1i")
-    fig.text(x=region[0], y=region[2], text="200 ns/yr", font='10p,Helvetica,black',
+    fig.text(x=region[0], y=region[2], text=f"{peak_dil} ns/yr", font='10p,Helvetica,black',
              offset='0.4i/0.1i')
-    fig.colorbar(position="JCR+w4.0i+v+o0.7i/0i", cmap=os.path.join(outdir, "mycpt.cpt"), truncate="-200/200",
+    fig.colorbar(position="JCR+w4.0i+v+o0.7i/0i", cmap=os.path.join(outdir, "mycpt.cpt"), truncate=f"-{peak_dil}/{peak_dil}",
                  frame=["x50", "y+LNanostr/yr"])
     print("Saving dilatation figure as %s." % outfile)
     fig.savefig(outfile)
@@ -150,11 +150,11 @@ def plot_I2nd(I2_array, station_vels, region, outdir, outfile, positive_eigs=(),
     return
 
 
-def plot_maxshear(max_shear_array, station_vels, region, outdir, outfile, positive_eigs=(), negative_eigs=()):
+def plot_maxshear(max_shear_array, station_vels, region, outdir, outfile, positive_eigs=(), negative_eigs=(),peak_max_shear=200):
     proj = 'M4i'
     fig = pygmt.Figure()
     scalesize = get_map_scale(region)
-    pygmt.makecpt(cmap="vik", series="0/300/2", truncate="0/1.0", background="o",
+    pygmt.makecpt(cmap="vik", series=f"0/{peak_max_shear}/2", truncate="0/1.0", background="o",
                   output=os.path.join(outdir, "mycpt.cpt"))
     fig.basemap(region=region, projection=proj, frame="+tMaximum Shear")
     fig.grdimage(max_shear_array, projection=proj, region=region, cmap=os.path.join(outdir, "mycpt.cpt"))
@@ -180,8 +180,8 @@ def plot_maxshear(max_shear_array, station_vels, region, outdir, outfile, positi
              pen='0.6p,black', direction=[[200], [0]], offset="0.9i/0.1i")
     fig.plot(x=region[0], y=region[2], style='v0.20+b+a40+gred+h0.5+p0.3p,black+z0.003+n0.3',
              pen='0.6p,black', direction=[[-200], [0]], offset="0.9i/0.1i")
-    fig.text(x=region[0], y=region[2], text="200 ns/yr", font='10p,Helvetica,black', offset='0.4i/0.1i')
-    fig.colorbar(position="JCR+w4.0i+v+o0.7i/0i", cmap=os.path.join(outdir, "mycpt.cpt"), truncate="0/300",
+    fig.text(x=region[0], y=region[2], text=f"{peak_max_shear} ns/yr", font='10p,Helvetica,black', offset='0.4i/0.1i')
+    fig.colorbar(position="JCR+w4.0i+v+o0.7i/0i", cmap=os.path.join(outdir, "mycpt.cpt"), truncate=f"0/{peak_max_shear}",
                  frame=["x50", "y+LNanostr/yr"])
     print("Saving MaxShear figure as %s." % outfile)
     fig.savefig(outfile)

--- a/Strain_Tools/strain/utilities.py
+++ b/Strain_Tools/strain/utilities.py
@@ -86,26 +86,6 @@ def get_gmt_range_inc(lons, lats):
     return gmt_range_string, gmt_inc_string
 
 
-# --------- DEFENSIVE PROGRAMMING FOR COMPARING MULTIPLE GRIDS ------------------ #
-
-def check_coregistered_shapes(strain_values_ds):
-    """
-    Make sure arrays are of the same dimensions before attempting to produce any statistics
-    
-    :param strain_values_ds: xarray.DataSet of strain values from different calculations
-    :returns: None
-    """
-    x = np.array(strain_values_ds['x'])
-    y = np.array(strain_values_ds['y'])
-    for varname, da in strain_values_ds.data_vars.items():
-        nparray = np.array(strain_values_ds[varname])
-        arrayshape = np.shape(nparray)
-        assert arrayshape == (len(y), len(x), ValueError(
-            "Error! Not all arrays have the same shape!  Cannot compare."))
-    print("All methods have the same shape.")
-    return
-
-
 # --------- GRID AND VELFIELD NAMED TUPLE UTILITIES ------------------ #
 
 def make_grid(coordbox, inc):

--- a/Strain_Tools/strain/velocity_io.py
+++ b/Strain_Tools/strain/velocity_io.py
@@ -34,7 +34,10 @@ def read_stationvels(input_file):
         except ValueError:
             continue
         lat, VE, VN, VU = float(temp[1]), float(temp[2]), float(temp[3]), float(temp[4])
-        SE, SN, SU = float(temp[5]), float(temp[6]), float(temp[7])
+        try:
+             SE, SN, SU = float(temp[5]), float(temp[6]), float(temp[7])
+        except:
+             breakpoint()
         if len(temp) > 8:
             name = temp[8]
         else:


### PR DESCRIPTION
# Description

- There's a few issues with handling the data and data residuals when using wavelets. In particular, the residuals may not be calculated for all the input data. This could be a general problem when running with wrappers, where an external code removes data for some reason. This PR modifies the data and residuals file I/O so that if residuals are not calculated for a station, the code will still complete. 
- Allow easier selection of mean vs median functions
- Calculates the mean and standard deviation of the strain rate tensors rather than the invariants. 

# Testing
- Works as expected for myself and student